### PR TITLE
Add parameter info for setSpeed

### DIFF
--- a/Premiere/12.0/qeDom.d.ts
+++ b/Premiere/12.0/qeDom.d.ts
@@ -370,15 +370,16 @@ interface QETrackItem {
    * Add a video effect to a QETrackItem
    *
    * @param speedFactor the speed factor ( 1 = 100% )
-   * @param unkown can leave a blank string
+   * @param duration Timecode string to set the clip's new length, or blank string to preserve duration (if sufficient source footage).
    * @param isReversed set if the clip speed should be reversed or not
-   * @param p3
-   * @param ripple
+   * @param p3 Unknown
+   * @param ripple Whether to ripple edit other clips on the track (Only matters if the length of the clip changes)
    * @example clip.setSpeed(1.5, '', true, true, true)
+   * @example clip.setSpeed(2.0, "00:00:22:15", false, true, false)
    */
   setSpeed(
     speeedFactor: number,
-    unkown: string,
+    duration: string,
     isReversed: boolean,
     p3: boolean,
     ripple: boolean,


### PR DESCRIPTION
I had a hunch that the unknown string parameter for the `QETrackItem.setSpeed()` method might take a timecode string, and I was right. It lets you explicitly set the duration of the clip on the timeline after setting the speed.

So I renamed the parameter from `unknown` to `duration` and added an example

I also added a description for the `ripple` parameter.


### Example usage:

```javascript
function main() {
    app.enableQE();
    var as = qe.project.getActiveSequence();
    var track0 = as.getVideoTrackAt(0);
    var clip = track0.getItemAt(0);
    clip.setSpeed(2.0, "00:00:22:30", false, true, false)
}
```
